### PR TITLE
Fix platform id type

### DIFF
--- a/tests/integration/test_get_guild_community_ids.py
+++ b/tests/integration/test_get_guild_community_ids.py
@@ -41,7 +41,7 @@ class TestGetGuildId(TestCase):
             }
         )
 
-        guild_id, community_id = get_guild_community_ids(platform_id)
+        guild_id, community_id = get_guild_community_ids(str(platform_id))
         self.assertEqual(guild_id, "999888877766655")
         self.assertEqual(community_id, "aabbccddeeff001122334455")
 
@@ -52,4 +52,4 @@ class TestGetGuildId(TestCase):
         client.drop_database("Core")
 
         with self.assertRaises(AttributeError):
-            get_guild_community_ids(platform_id)
+            get_guild_community_ids(str(platform_id))

--- a/utils/get_guild_community_ids.py
+++ b/utils/get_guild_community_ids.py
@@ -2,7 +2,7 @@ from bson.objectid import ObjectId
 from utils.get_mongo_client import MongoSingleton
 
 
-def get_guild_community_ids(platform_id: ObjectId) -> tuple[str, str]:
+def get_guild_community_ids(platform_id: str) -> tuple[str, str]:
     """
     get both the guild id and community from the platform id
 
@@ -20,8 +20,9 @@ def get_guild_community_ids(platform_id: ObjectId) -> tuple[str, str]:
     """
     mongo_client = MongoSingleton.get_instance().client
 
+    obj_platform_id = ObjectId(platform_id)
     platform = mongo_client["Core"]["platforms"].find_one(
-        {"name": "discord", "_id": platform_id}
+        {"name": "discord", "_id": obj_platform_id}
     )
     if platform is None:
         raise AttributeError(f"PLATFORM_ID: {platform_id}, No guild found!")


### PR DESCRIPTION
Previously we were reading the platformId as a string and sending the the find function but we had to convert it to bson.ObjectId