### PR TITLE
fix: memberactivities analytics range!

### DIFF
--- a/discord_analyzer/analysis/compute_member_activity.py
+++ b/discord_analyzer/analysis/compute_member_activity.py
@@ -184,7 +184,7 @@ def compute_member_activity(
         # no analytics for the days would be computed
         # so make it as a window_d lenght to have the computations
         new_date_range_interval = (new_date_range[1] - new_date_range[0]).days
-        if new_date_range_interval < window_param["period_size"] - 1:
+        if load_past_data is True:
             interval_before = (new_date_range_interval) + (
                 window_param["period_size"] - 1
             )


### PR DESCRIPTION
As the analytics for a specific date should be a range of `[specific_date - window_size, specific_date]`, we should've to go always `window_size` days back to compute that day's analytics. The condition we updated is for the time when we're computing daily analytics and loading the previous analytics in memory.